### PR TITLE
Update UI elements

### DIFF
--- a/src/AllenNeuralDynamics.Core.Design/AllenNeuralDynamics.Core.Design.csproj
+++ b/src/AllenNeuralDynamics.Core.Design/AllenNeuralDynamics.Core.Design.csproj
@@ -9,7 +9,7 @@
     <PackageTags>Bonsai Rx Core AllenNeuralDynamics</PackageTags>
     <TargetFramework>net472</TargetFramework>
     <Features>strict</Features>
-    <Version>0.1.3-preview2024013102</Version>
+    <Version>0.1.4-preview2024020101</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AllenNeuralDynamics.Core.Design/PropertyGridSource.cs
+++ b/src/AllenNeuralDynamics.Core.Design/PropertyGridSource.cs
@@ -13,7 +13,12 @@ namespace AllenNeuralDynamics.Core.Design
 
         public override IObservable<Unit> Generate()
         {
-            return(Observable.Never(new Unit()));
+            return Observable.Timer(TimeSpan.Zero, TimeSpan.FromSeconds(0.2)).Select(x => new Unit());
+        }
+
+        public IObservable<Unit> Generate<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(source => new Unit());
         }
     }
 }

--- a/src/AllenNeuralDynamics.Core.Design/PropertyGridVisualizer.cs
+++ b/src/AllenNeuralDynamics.Core.Design/PropertyGridVisualizer.cs
@@ -41,6 +41,7 @@ public class PropertyGridVisualizer : DialogTypeVisualizer
 
     public override void Show(object value)
     {
+        control.Refresh();
     }
 
     public override void Unload()

--- a/src/AllenNeuralDynamics.Core.Design/PushButton.cs
+++ b/src/AllenNeuralDynamics.Core.Design/PushButton.cs
@@ -1,10 +1,11 @@
-﻿using Bonsai;
-using System;
+﻿using System;
 using System.ComponentModel;
+using System.Drawing;
 using System.Reactive;
 using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
+using Bonsai;
 
 namespace AllenNeuralDynamics.Core.Design
 {
@@ -12,22 +13,48 @@ namespace AllenNeuralDynamics.Core.Design
     [WorkflowElementCategory(ElementCategory.Source)]
     [TypeVisualizer(typeof(PushButtonVisualizer))]
     [Description("Generates a sequence of Unit events.")]
+
     public class PushButton
     {
         readonly Subject<Unit> subject = new Subject<Unit>();
 
         public PushButton() { }
 
-        [DesignOnly(true)]
         public string Label { get; set; }
+
+        private EventHandler onEnableChanged;
+        public event EventHandler OnEnableChanged
+        {
+            add { onEnableChanged += value; }
+            remove { onEnableChanged += value; }
+        }
+
+        private bool enabled = true;
+        public bool Enabled
+        {
+            get { return enabled; }
+            set
+            {
+                enabled = value;
+                onEnableChanged?.Invoke(
+                    this,
+                    new EnabledChangedEventArgs { Enabled = enabled });
+            }
+        }
+
 
         public void OnNext(Unit value) { 
             subject.OnNext(value);
         }
 
         public virtual IObservable<Unit> Process()
-        {
+        {   
             return subject.ObserveOn(Scheduler.TaskPool);
+        }
+
+        public class EnabledChangedEventArgs : EventArgs
+        {
+            public bool Enabled { get; set; }
         }
     }
 }

--- a/src/AllenNeuralDynamics.Core.Design/PushButtonControl.Designer.cs
+++ b/src/AllenNeuralDynamics.Core.Design/PushButtonControl.Designer.cs
@@ -55,7 +55,7 @@
             this.button.TabIndex = 0;
             this.button.Text = "Push";
             this.button.UseVisualStyleBackColor = true;
-            this.button.Click += new System.EventHandler(this.tareButton_Click);
+            this.button.Click += new System.EventHandler(this.button_click);
             // 
             // PushButtonControl
             // 

--- a/src/AllenNeuralDynamics.Core.Design/PushButtonControl.cs
+++ b/src/AllenNeuralDynamics.Core.Design/PushButtonControl.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Reactive;
 using System.Windows.Forms;
+using static AllenNeuralDynamics.Core.Design.PushButton;
 
 namespace AllenNeuralDynamics.Core.Design
 {
@@ -13,13 +14,24 @@ namespace AllenNeuralDynamics.Core.Design
             set { button.Text = value;} 
         }
 
+        private void HandleEnableChanges(object sender, EventArgs e)
+        {
+            if (InvokeRequired)
+            {
+                BeginInvoke(new EventHandler(HandleEnableChanges), sender, e);
+                return;
+            }
+            Enabled = ((EnabledChangedEventArgs)e).Enabled;
+        }
+
         public PushButtonControl(PushButton source)
         {
             Source = source ?? throw new ArgumentNullException(nameof(source));
+            Source.OnEnableChanged += HandleEnableChanges;
             InitializeComponent();
         }
 
-        private void tareButton_Click(object sender, EventArgs e)
+        private void button_click(object sender, EventArgs e)
         {
             Source.OnNext(Unit.Default);
         }

--- a/src/AllenNeuralDynamics.Core.Design/PushButtonVisualizer.cs
+++ b/src/AllenNeuralDynamics.Core.Design/PushButtonVisualizer.cs
@@ -18,7 +18,8 @@ namespace AllenNeuralDynamics.Core.Design
             control = new PushButtonControl(source);
             control.Dock = DockStyle.Fill;
             control.ButtonLabel = source.Label;
-
+            control.Enabled = source.Enabled;
+            
             var visualizerService = (IDialogTypeVisualizerService)provider.GetService(typeof(IDialogTypeVisualizerService));
             if (visualizerService != null)
             {

--- a/src/AllenNeuralDynamics.Core.Design/ToggleButton.cs
+++ b/src/AllenNeuralDynamics.Core.Design/ToggleButton.cs
@@ -1,9 +1,9 @@
-﻿using Bonsai;
-using System;
+﻿using System;
 using System.ComponentModel;
 using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
+using Bonsai;
 
 namespace AllenNeuralDynamics.Core.Design
 {
@@ -13,16 +13,31 @@ namespace AllenNeuralDynamics.Core.Design
     [Description("Generates a sequence of commands to tare a weight scale.")]
     public class ToggleButton
     {
-        [DesignOnly(true)]
-        public string CheckedLabel { get; set; } = "Turn Off.";
-        
-        [DesignOnly(true)]
-        public string UncheckedLabel { get; set; } = "Turn On.";
+        private EventHandler onEnabledChanged;
+        public event EventHandler OnEnabledChanged
+        {
+            add { onEnabledChanged += value; }
+            remove { onEnabledChanged += value; }
+        }
 
+        private bool enabled = true;
+        public bool Enabled
+        {
+            get { return enabled; }
+            set
+            {
+                enabled = value;
+                onEnabledChanged?.Invoke(this, new ToggleEnabledStateEventArgs { Enabled = enabled });
+            }
+        }
+
+        readonly Subject<bool> subject = new Subject<bool>();
+        
         [DesignOnly(true)]
         public bool IsInitiallyChecked { get; set; } = false;
-        
-        readonly Subject<bool> subject = new Subject<bool>();
+
+        public string CheckedLabel { get; set; } = "Turn Off.";
+        public string UncheckedLabel { get; set; } = "Turn On.";
 
         public ToggleButton() { }
 
@@ -37,8 +52,8 @@ namespace AllenNeuralDynamics.Core.Design
         }
     }
 
-    public class ToggleStateChangedEventArgs : EventArgs
+    public class ToggleEnabledStateEventArgs : EventArgs
     {
-        public bool State { get; set; }
+        public bool Enabled { get; set; }
     }
 }

--- a/src/AllenNeuralDynamics.Core.Design/ToggleButtonControl.cs
+++ b/src/AllenNeuralDynamics.Core.Design/ToggleButtonControl.cs
@@ -7,11 +7,26 @@ namespace AllenNeuralDynamics.Core.Design
     {
         public ToggleButton Source { get; }
 
+        public string CheckedLabel { get; set; }
+        public string UncheckedLabel { get; set; }
+
+        private void HandleEnabledChanges(object sender, EventArgs e)
+        {
+            if (InvokeRequired)
+            {
+                BeginInvoke(new EventHandler(HandleEnabledChanges), sender, e);
+                return;
+            }
+            Enabled = ((ToggleEnabledStateEventArgs)e).Enabled;
+        }
+
         public ToggleButtonStateControl(ToggleButton source)
         {
             Source = source ?? throw new ArgumentNullException(nameof(source));
+            Source.OnEnabledChanged += HandleEnabledChanges;
             InitializeComponent();
             State = Source.IsInitiallyChecked;
+            Enabled = Source.Enabled;
         }
 
         public bool State
@@ -23,7 +38,7 @@ namespace AllenNeuralDynamics.Core.Design
             set
             {
                 toggleButton.Checked = value == true;
-                toggleButton.Text = toggleButton.Checked ? Source.CheckedLabel : Source.UncheckedLabel;
+                toggleButton.Text = toggleButton.Checked ? CheckedLabel : UncheckedLabel;
             }
         }
 

--- a/src/AllenNeuralDynamics.Core.Design/ToggleButtonVisualizer.cs
+++ b/src/AllenNeuralDynamics.Core.Design/ToggleButtonVisualizer.cs
@@ -2,6 +2,8 @@
 using Bonsai.Design;
 using Bonsai.Expressions;
 using System.Windows.Forms;
+using Bonsai;
+using static System.Windows.Forms.AxHost;
 
 namespace AllenNeuralDynamics.Core.Design
 {
@@ -16,6 +18,9 @@ namespace AllenNeuralDynamics.Core.Design
             var source = (ToggleButton)ExpressionBuilder.GetWorkflowElement(visualizerElement.Builder);
             control = new ToggleButtonStateControl(source);
             control.Dock = DockStyle.Fill;
+            control.UncheckedLabel = source.UncheckedLabel;
+            control.CheckedLabel = source.CheckedLabel;
+            control.State = source.IsInitiallyChecked;
 
             var visualizerService = (IDialogTypeVisualizerService)provider.GetService(typeof(IDialogTypeVisualizerService));
             if (visualizerService != null)
@@ -26,7 +31,7 @@ namespace AllenNeuralDynamics.Core.Design
 
         public override void Show(object value)
         {
-            control.State = (bool) value;
+            control.State = (bool)value;
         }
 
         public override void Unload()


### PR DESCRIPTION
This PR adds a small update to the UI elements:

ToggleButton and PushBotton can now be enabled/disabled via an exposed operator property
The property grid visualizer was also refactored to allow automatic refreshes (locked at 10Hz) or driven by an external input