### PR TITLE
Deprecate UI operators

### DIFF
--- a/src/AllenNeuralDynamics.Core.Design/AllenNeuralDynamics.Core.Design.csproj
+++ b/src/AllenNeuralDynamics.Core.Design/AllenNeuralDynamics.Core.Design.csproj
@@ -9,7 +9,7 @@
     <PackageTags>Bonsai Rx Core AllenNeuralDynamics</PackageTags>
     <TargetFramework>net472</TargetFramework>
     <Features>strict</Features>
-    <Version>0.1.4</Version>
+    <Version>0.1.5</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AllenNeuralDynamics.Core.Design/PropertyGridSource.cs
+++ b/src/AllenNeuralDynamics.Core.Design/PropertyGridSource.cs
@@ -6,6 +6,7 @@ using System.Reactive.Linq;
 
 namespace AllenNeuralDynamics.Core.Design
 {
+    [Obsolete]
     [TypeVisualizer(typeof(PropertyGridVisualizer))]
     [Description("Generates a sequence of string events.")]
     public class PropertyGridSource : Source<Unit> { 

--- a/src/AllenNeuralDynamics.Core.Design/PushButton.cs
+++ b/src/AllenNeuralDynamics.Core.Design/PushButton.cs
@@ -8,6 +8,7 @@ using Bonsai;
 
 namespace AllenNeuralDynamics.Core.Design
 {
+    [Obsolete]
     [Combinator]
     [WorkflowElementCategory(ElementCategory.Source)]
     [TypeVisualizer(typeof(PushButtonVisualizer))]

--- a/src/AllenNeuralDynamics.Core.Design/ToggleButton.cs
+++ b/src/AllenNeuralDynamics.Core.Design/ToggleButton.cs
@@ -7,6 +7,7 @@ using Bonsai;
 
 namespace AllenNeuralDynamics.Core.Design
 {
+    [Obsolete]
     [Combinator]
     [WorkflowElementCategory(ElementCategory.Source)]
     [TypeVisualizer(typeof(ToggleButtonVisualizer))]


### PR DESCRIPTION
This PR deprecates the UI operators in favor of the new core operators from Bonsai.GUI package.

Closes #26 