### PR TITLE
HotFix - Ensure motors are enabled during initial configuration

### DIFF
--- a/src/AllenNeuralDynamics.AindManipulator/AindManipulator.bonsai
+++ b/src/AllenNeuralDynamics.AindManipulator/AindManipulator.bonsai
@@ -265,6 +265,11 @@
                             <Value>1</Value>
                           </Combinator>
                         </Expression>
+                        <Expression xsi:type="Combinator">
+                          <Combinator xsi:type="rx:Take">
+                            <rx:Count>1</rx:Count>
+                          </Combinator>
+                        </Expression>
                         <Expression xsi:type="SubscribeSubject">
                           <Name>Motor</Name>
                         </Expression>
@@ -301,17 +306,18 @@
                       <Edges>
                         <Edge From="0" To="1" Label="Source1" />
                         <Edge From="1" To="2" Label="Source1" />
-                        <Edge From="3" To="13" Label="Source1" />
+                        <Edge From="3" To="14" Label="Source1" />
                         <Edge From="4" To="5" Label="Source1" />
-                        <Edge From="5" To="13" Label="Source2" />
-                        <Edge From="6" To="11" Label="Source1" />
-                        <Edge From="7" To="8" Label="Source1" />
+                        <Edge From="5" To="14" Label="Source2" />
+                        <Edge From="6" To="7" Label="Source1" />
+                        <Edge From="7" To="12" Label="Source1" />
                         <Edge From="8" To="9" Label="Source1" />
                         <Edge From="9" To="10" Label="Source1" />
-                        <Edge From="10" To="11" Label="Source2" />
-                        <Edge From="11" To="12" Label="Source1" />
-                        <Edge From="12" To="13" Label="Source3" />
-                        <Edge From="13" To="14" Label="Source1" />
+                        <Edge From="10" To="11" Label="Source1" />
+                        <Edge From="11" To="12" Label="Source2" />
+                        <Edge From="12" To="13" Label="Source1" />
+                        <Edge From="13" To="14" Label="Source3" />
+                        <Edge From="14" To="15" Label="Source1" />
                       </Edges>
                     </Workflow>
                   </Expression>
@@ -354,6 +360,11 @@
                   <Expression xsi:type="Combinator">
                     <Combinator xsi:type="ByteProperty">
                       <Value>1</Value>
+                    </Combinator>
+                  </Expression>
+                  <Expression xsi:type="Combinator">
+                    <Combinator xsi:type="rx:Take">
+                      <rx:Count>1</rx:Count>
                     </Combinator>
                   </Expression>
                   <Expression xsi:type="SubscribeSubject">
@@ -411,25 +422,26 @@
                 </Nodes>
                 <Edges>
                   <Edge From="0" To="1" Label="Source1" />
-                  <Edge From="1" To="10" Label="Source1" />
-                  <Edge From="2" To="9" Label="Source1" />
-                  <Edge From="3" To="4" Label="Source1" />
+                  <Edge From="1" To="11" Label="Source1" />
+                  <Edge From="2" To="3" Label="Source1" />
+                  <Edge From="3" To="10" Label="Source1" />
                   <Edge From="4" To="5" Label="Source1" />
                   <Edge From="5" To="6" Label="Source1" />
                   <Edge From="6" To="7" Label="Source1" />
                   <Edge From="7" To="8" Label="Source1" />
-                  <Edge From="8" To="9" Label="Source2" />
+                  <Edge From="8" To="9" Label="Source1" />
                   <Edge From="9" To="10" Label="Source2" />
-                  <Edge From="10" To="11" Label="Source1" />
+                  <Edge From="10" To="11" Label="Source2" />
                   <Edge From="11" To="12" Label="Source1" />
                   <Edge From="12" To="13" Label="Source1" />
-                  <Edge From="12" To="14" Label="Source1" />
-                  <Edge From="13" To="16" Label="Source1" />
-                  <Edge From="14" To="15" Label="Source1" />
-                  <Edge From="15" To="16" Label="Source2" />
-                  <Edge From="16" To="17" Label="Source1" />
+                  <Edge From="13" To="14" Label="Source1" />
+                  <Edge From="13" To="15" Label="Source1" />
+                  <Edge From="14" To="17" Label="Source1" />
+                  <Edge From="15" To="16" Label="Source1" />
+                  <Edge From="16" To="17" Label="Source2" />
                   <Edge From="17" To="18" Label="Source1" />
                   <Edge From="18" To="19" Label="Source1" />
+                  <Edge From="19" To="20" Label="Source1" />
                 </Edges>
               </Workflow>
             </Expression>
@@ -562,6 +574,11 @@
                             <Value>1</Value>
                           </Combinator>
                         </Expression>
+                        <Expression xsi:type="Combinator">
+                          <Combinator xsi:type="rx:Take">
+                            <rx:Count>1</rx:Count>
+                          </Combinator>
+                        </Expression>
                         <Expression xsi:type="SubscribeSubject">
                           <Name>Motor</Name>
                         </Expression>
@@ -595,17 +612,18 @@
                       <Edges>
                         <Edge From="0" To="1" Label="Source1" />
                         <Edge From="1" To="2" Label="Source1" />
-                        <Edge From="3" To="13" Label="Source1" />
+                        <Edge From="3" To="14" Label="Source1" />
                         <Edge From="4" To="5" Label="Source1" />
-                        <Edge From="5" To="13" Label="Source2" />
-                        <Edge From="6" To="11" Label="Source1" />
-                        <Edge From="7" To="8" Label="Source1" />
+                        <Edge From="5" To="14" Label="Source2" />
+                        <Edge From="6" To="7" Label="Source1" />
+                        <Edge From="7" To="12" Label="Source1" />
                         <Edge From="8" To="9" Label="Source1" />
                         <Edge From="9" To="10" Label="Source1" />
-                        <Edge From="10" To="11" Label="Source2" />
-                        <Edge From="11" To="12" Label="Source1" />
-                        <Edge From="12" To="13" Label="Source3" />
-                        <Edge From="13" To="14" Label="Source1" />
+                        <Edge From="10" To="11" Label="Source1" />
+                        <Edge From="11" To="12" Label="Source2" />
+                        <Edge From="12" To="13" Label="Source1" />
+                        <Edge From="13" To="14" Label="Source3" />
+                        <Edge From="14" To="15" Label="Source1" />
                       </Edges>
                     </Workflow>
                   </Expression>

--- a/src/AllenNeuralDynamics.AindManipulator/AllenNeuralDynamics.AindManipulator.csproj
+++ b/src/AllenNeuralDynamics.AindManipulator/AllenNeuralDynamics.AindManipulator.csproj
@@ -7,12 +7,13 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Bonsai Rx Manipulator AllenNeuralDynamics</PackageTags>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net480</TargetFramework>
     <Features>strict</Features>
-    <Version>0.1.0-preview2024061101</Version>
+    <Version>0.1.0-preview2024061102</Version>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Bonsai" Version="2.8.3" />
     <PackageReference Include="Bonsai.Gui" Version="0.1.0" />
     <PackageReference Include="Bonsai.Scripting.Expressions" Version="2.8.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />


### PR DESCRIPTION
This PR fixes a bug where the byte (=1) sequence used for the bitshift operation to assign the bit mask corresponding to each motor was not terminating correctly.