### PR TITLE
Expose camera sensor ROI in camera capture operator

### DIFF
--- a/src/AllenNeuralDynamics.Core/AindSpinnakerCapture.cs
+++ b/src/AllenNeuralDynamics.Core/AindSpinnakerCapture.cs
@@ -74,14 +74,23 @@ namespace AllenNeuralDynamics.Core
         private void SetRegionOfInterest(IManagedCamera camera)
         {
             if (!(RegionOfInterest.Width == 0 || RegionOfInterest.Height == 0))
-            {
-                camera.OffsetX.Value = RegionOfInterest.X;
-                camera.OffsetY.Value = RegionOfInterest.Y;
+            { 
+                // Ensure that offsets are 0 before setting width and height
+                camera.OffsetX.Value = 0;
+                camera.OffsetY.Value = 0;
+
                 camera.Width.Value = RegionOfInterest.Width;
                 camera.Height.Value = RegionOfInterest.Height;
+
+                // Set the offset to the top left corner of the region of interest
+                // Passing a valid value is the responsibility of the user
+                camera.OffsetX.Value = RegionOfInterest.X;
+                camera.OffsetY.Value = RegionOfInterest.Y;
             }
             else
             {
+                // If the region of interest is not set, set the width and height to the maximum values
+                // allowed by the sensor
                 camera.Width.Value = camera.WidthMax.Value;
                 camera.Height.Value = camera.HeightMax.Value;
             }

--- a/src/AllenNeuralDynamics.Core/AindSpinnakerCapture.cs
+++ b/src/AllenNeuralDynamics.Core/AindSpinnakerCapture.cs
@@ -1,6 +1,7 @@
 ﻿using System.ComponentModel;
 using Bonsai.Spinnaker;
 using SpinnakerNET;
+using OpenCV.Net;
 
 namespace AllenNeuralDynamics.Core
 {
@@ -32,6 +33,8 @@ namespace AllenNeuralDynamics.Core
 
         [Description("Sensor pixel format.")]
         public PixelFormatEnums PixelFormat { get; set; }
+
+        public Rect RegionOfInterest { get; set; } = new Rect(0,0,0,0);
 
         protected override void Configure(IManagedCamera camera)
         {
@@ -66,6 +69,22 @@ namespace AllenNeuralDynamics.Core
             }
 
             base.Configure(camera);
+        }
+
+        private void SetRegionOfInterest(IManagedCamera camera)
+        {
+            if (!(RegionOfInterest.Width == 0 || RegionOfInterest.Height == 0))
+            {
+                camera.OffsetX.Value = RegionOfInterest.X;
+                camera.OffsetY.Value = RegionOfInterest.Y;
+                camera.Width.Value = RegionOfInterest.Width;
+                camera.Height.Value = RegionOfInterest.Height;
+            }
+            else
+            {
+                camera.Width.Value = camera.WidthMax.Value;
+                camera.Height.Value = camera.HeightMax.Value;
+            }
         }
     }
 }

--- a/src/AllenNeuralDynamics.Core/AllenNeuralDynamics.Core.csproj
+++ b/src/AllenNeuralDynamics.Core/AllenNeuralDynamics.Core.csproj
@@ -9,7 +9,7 @@
     <PackageTags>Bonsai Rx Core AllenNeuralDynamics</PackageTags>
     <TargetFramework>net472</TargetFramework>
     <Features>strict</Features>
-    <Version>0.2.1</Version>
+    <Version>0.2.2</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #69 

Based on @lambdaloop recipe:

```python 
    # cropping 
    camera.camera_nodes.OffsetX.set_node_value(0)
    camera.camera_nodes.OffsetY.set_node_value(0)
    camera.camera_nodes.Width.set_node_value(width)
    camera.camera_nodes.Height.set_node_value(height)
    camera.camera_nodes.OffsetX.set_node_value(offset_x)
    camera.camera_nodes.OffsetY.set_node_value(offset_y)
 
```