### PR TITLE
Handle 16bit pixel formats

### DIFF
--- a/src/AllenNeuralDynamics.Core/AindSpinnakerCapture.cs
+++ b/src/AllenNeuralDynamics.Core/AindSpinnakerCapture.cs
@@ -32,20 +32,23 @@ namespace AllenNeuralDynamics.Core
         [Description("Parameter used for gamma correction. If null, gamma correction is disabled.")]
         public double? Gamma { get; set; }
 
-        [Description("Sensor pixel format.")]
-        public PixelFormatEnums PixelFormat { get; set; }
+        [Description("Sensor pixel format. If null, the currently set value in the camera will be used.")]
+        public PixelFormatEnums? PixelFormat { get; set; }
 
         [Description("Region of interest to crop the sensor with.")]
         public Rect RegionOfInterest { get; set; } = new Rect(0,0,0,0);
 
-        [Description("Sensor ADC bit depth used to acquired data.")]
+        [Description("Sensor ADC bit depth used to acquired data. If null the currently set value in the camera will be used.")]
         public AdcBitDepthEnums? AdcBitDepth { get; set; }
 
         protected override void Configure(IManagedCamera camera)
         {
             try { camera.AcquisitionStop.Execute(); }
             catch { }
-            camera.PixelFormat.Value = PixelFormat.ToString();
+            if (PixelFormat.HasValue)
+            {
+                camera.PixelFormat.Value = PixelFormat.Value.ToString();
+            }
             if (AdcBitDepth.HasValue)
             {
                 camera.AdcBitDepth.Value = AdcBitDepth.Value.ToString();

--- a/src/AllenNeuralDynamics.Core/AllenNeuralDynamics.Core.csproj
+++ b/src/AllenNeuralDynamics.Core/AllenNeuralDynamics.Core.csproj
@@ -9,7 +9,7 @@
     <PackageTags>Bonsai Rx Core AllenNeuralDynamics</PackageTags>
     <TargetFramework>net472</TargetFramework>
     <Features>strict</Features>
-    <Version>0.2.8</Version>
+    <Version>0.2.9</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AllenNeuralDynamics.Core/FfmpegVideoWriter.cs
+++ b/src/AllenNeuralDynamics.Core/FfmpegVideoWriter.cs
@@ -51,13 +51,20 @@ namespace AllenNeuralDynamics.Core
                 var writer = new ImageWriter { Path = pipe };
                 return writer.Process(ps).Merge(ps.Take(1).Delay(TimeSpan.FromSeconds(1)).SelectMany(image =>
                 {
+                    string pixelFormat;
+                    if (image.Channels == 1 && image.Depth==IplDepth.U8) pixelFormat = "gray";
+                    else if (image.Channels == 3 && image.Depth == IplDepth.U8) pixelFormat = "bgr24";
+                    else if (image.Channels == 1 && image.Depth == IplDepth.U16) pixelFormat = "gray16le";
+                    else if (image.Channels == 3 && image.Depth == IplDepth.U16) pixelFormat = "bgr48le";
+                    else throw new InvalidOperationException(string.Format("Unsupported image format. Got {0} channels and depth {1}", image.Channels, image.Depth));
+
                     var inputArguments = string.Format("-v {0} {1}", Verbosity.ToString().ToLower(), InputArguments);
                     var args = string.Format("-f rawvideo -vcodec rawvideo {0}-s {1}x{2} -r {3} -pix_fmt {4} {5} -i {6} {7} {8}",
                         overwrite ? "-y " : string.Empty,
                         image.Width,
                         image.Height,
                         FrameRate,
-                        image.Channels == 1 ? "gray" : "bgr24",
+                        pixelFormat,
                         inputArguments,
                         pipe,
                         OutputArguments,

--- a/src/AllenNeuralDynamics.Core/FfmpegVideoWriter.cs
+++ b/src/AllenNeuralDynamics.Core/FfmpegVideoWriter.cs
@@ -29,7 +29,7 @@ namespace AllenNeuralDynamics.Core
 
         [Editor(DesignTypes.MultilineStringEditor, DesignTypes.UITypeEditor)]
         [Description("The optional set of command-line arguments to use for configuring the video codec.")]
-        public string OutputArguments { get; set; } = @"-vf ""scale=out_color_matrix=bt709:out_range=full"" -c:v h264_nvenc -pix_fmt nv12 -color_range full -colorspace bt709 -color_trc linear -tune hq -preset p4 -rc vbr -cq 12 -b:v 0M -metadata author=""Allen Institute for Neural Dynamics"" -maxrate 700M -bufsize 350M";
+        public string OutputArguments { get; set; } = @"-vf ""scale=out_color_matrix=bt709:out_range=full:sws_dither=none,format=yuv420p10le,colorspace=ispace=bt709:all=bt709:dither=none,scale=out_range=tv:sws_dither=none,format=yuv420p"" -c:v libx264 -preset veryslow -crf 18 -pix_fmt yuv420p -metadata author=""Allen Institute for Neural Dynamics"" -movflags +faststart+write_colr";
 
         [Editor(DesignTypes.MultilineStringEditor, DesignTypes.UITypeEditor)]
         [Description("The optional set of command-line arguments to use for configuring the input video stream.")]


### PR DESCRIPTION
This PR:
- Ensures that both 8 and 16bit formats (U8 and U16) are honored by the writer operator
- Exposes the Pixel format property of the spinnaker capture operator
- Updates the encoding screen as merged in https://github.com/AllenNeuralDynamics/Aind.Behavior.Services/pull/117